### PR TITLE
layer 配置方式修改

### DIFF
--- a/demo-egg-layer/serverless.yml
+++ b/demo-egg-layer/serverless.yml
@@ -11,7 +11,8 @@ functions:
           method: get
 
 layers:
-  eggLayer: npm:@midwayjs/egg-layer
+  eggLayer: 
+    path: npm:@midwayjs/egg-layer
 
 plugins:
   - serverless-midway-plugin


### PR DESCRIPTION
serverless-midway-plugin 最新版本的代码中读取了某个 layer 的 path 属性，按照之前的方式写配置文件会报 `TypeError: Cannot read property 'split' of undefined` 错误。

[serverless-midway-plugin 中的定义](https://github.com/midwayjs/midway-faas/blob/bd13629df21ee18a532cbec4ba1768aae047c2fc/packages/serverless-midway-plugin/src/core/utils.ts#L6)
